### PR TITLE
Switch to uuid over node-uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "enchannel": "^1.1.2",
     "enchannel-zmq-backend": "^1.1.0",
     "express": "^4.13.4",
-    "node-uuid": "^1.4.7",
+    "uuid": "^2.0.2",
     "socket.io": "^1.4.5",
     "spawnteract": "^1.0.2"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const app = require('express')();
 const http = require('http').Server(app);
-const uuid = require('node-uuid').v4;
+const uuid = require('uuid').v4;
 const spawnteract = require('spawnteract');
 const enchannel = require('enchannel');
 const enchannelBackend = require('enchannel-zmq-backend');


### PR DESCRIPTION
Switch to uuid over node-uuid. We've been inconsistently using either one. We'll be sticking with uuid per broofa/node-uuid#116